### PR TITLE
Add support for semver ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ $ check-packages <checklist.json> [options]
 
 ### Checklist JSON File
 
-The content of the checklist file must be an array of package names (with optional [semver ranges](https://docs.npmjs.com/misc/semver#ranges)), e.g.:
+The content of the checklist file must be an array of package names (with optional [semver ranges](https://semver.npmjs.com/)), e.g.:
 ```json
 [
   "react",

--- a/README.md
+++ b/README.md
@@ -30,9 +30,14 @@ $ check-packages <checklist.json> [options]
 
 ### Checklist JSON File
 
-The content of the checklist file must be an array of package names, e.g.:
+The content of the checklist file must be an array of package names (with optional [semver ranges](https://docs.npmjs.com/misc/semver#ranges)), e.g.:
 ```json
-[ "react", "react-dom", "redux", "react-redux" ]
+[
+  "react",
+  "react-dom",
+  "redux@>=1.0.0-rc.0 <1.0.1",
+  "react-redux@^2 <2.2 || > 2.3"
+]
 ```
 
 By default `check-packages` uses the checklist path `packages-whitelist.json`

--- a/lib/analyze-dependencies.js
+++ b/lib/analyze-dependencies.js
@@ -3,6 +3,7 @@
 const readChecklistFile = require('./read-checklist-file');
 const readDependencies = require('./read-dependencies');
 const flattenDependencyTree = require('./flatten-dependency-tree');
+const semver = require('semver');
 
 const analyzeDependencies = options => {
   const result = {
@@ -42,10 +43,27 @@ const analyzeDependencies = options => {
     return result;
   }
 
-  const whitelistCheck = pkgName => listedPackages.includes(pkgName) === false;
-  const blacklistCheck = pkgName => listedPackages.includes(pkgName) === true;
+  const isUnallowed = pkgName => {
+    const installedVersions = installedPackages[pkgName];
+    const listedPackage = listedPackages.find(item => item.packageName === pkgName);
 
-  result.unallowedPackages = Object.keys(installedPackages).filter(options.blacklist ? blacklistCheck : whitelistCheck);
+    if (!listedPackage) {
+      return false;
+    }
+
+    if (listedPackage && !listedPackage.versionRange) {
+      return true;
+    }
+
+    return installedVersions.
+      some(version => semver.satisfies(version, listedPackage.versionRange));
+  };
+
+  const whitelistCheck = pkgName => isUnallowed(pkgName) === false;
+  const blacklistCheck = pkgName => isUnallowed(pkgName) === true;
+
+  result.unallowedPackages = Object.keys(installedPackages).
+    filter(options.blacklist ? blacklistCheck : whitelistCheck);
 
   result.verboseOutput = result.unallowedPackages.
     sort().

--- a/lib/analyze-dependencies.test.js
+++ b/lib/analyze-dependencies.test.js
@@ -10,26 +10,26 @@ jest.mock('./read-dependencies', () => jest.fn());
 
 const exampleDependencyTree = {
   name: 'A',
-  version: 'v1.0.0',
+  version: '1.0.0',
   dependencies: {
     AA: {
-      version: 'v1.1.0',
+      version: '1.1.0',
       dependencies: {
         AAA: {
-          version: 'v1.1.1',
+          version: '1.1.1',
           dependencies: {
             AB: {
-              version: 'v1.1.5'
+              version: '1.1.5'
             }
           }
         }
       }
     },
     AB: {
-      version: 'v1.1.1',
+      version: '1.1.1',
       dependencies: {
         AABB: {
-          version: 'v1.1.3'
+          version: '1.1.3'
         }
       }
     }
@@ -97,7 +97,7 @@ describe('analyzeDependencies', () => {
   });
 
   it('returns expected object when packages whitelisting analyzed successfully', () => {
-    readChecklistFile.mockImplementation(() => [ 'A', 'AA' ]);
+    readChecklistFile.mockImplementation(() => [{ packageName: 'A' }, { packageName: 'AA' }]);
     readDependencies.mockImplementation(() => ({
       tree: exampleDependencyTree
     }));
@@ -108,7 +108,7 @@ describe('analyzeDependencies', () => {
     const expected = {
       error: '',
       unallowedPackages: [ 'AAA', 'AABB', 'AB' ],
-      verboseOutput: '- AAA [v1.1.1]\n- AABB [v1.1.3]\n- AB [v1.1.1, v1.1.5]',
+      verboseOutput: '- AAA [1.1.1]\n- AABB [1.1.3]\n- AB [1.1.1, 1.1.5]',
       warning: ''
     };
     const actual = analyzeDependencies(options);
@@ -117,7 +117,7 @@ describe('analyzeDependencies', () => {
   });
 
   it('returns expected object when packages blacklisting analyzed successfully', () => {
-    readChecklistFile.mockImplementation(() => [ 'AAA', 'AABB', 'AB' ]);
+    readChecklistFile.mockImplementation(() => [{ packageName: 'AAA' }, { packageName: 'AABB' }, { packageName: 'AB' }]);
     readDependencies.mockImplementation(() => ({
       tree: exampleDependencyTree
     }));
@@ -129,7 +129,7 @@ describe('analyzeDependencies', () => {
     const expected = {
       error: '',
       unallowedPackages: [ 'AAA', 'AABB', 'AB' ],
-      verboseOutput: '- AAA [v1.1.1]\n- AABB [v1.1.3]\n- AB [v1.1.1, v1.1.5]',
+      verboseOutput: '- AAA [1.1.1]\n- AABB [1.1.3]\n- AB [1.1.1, 1.1.5]',
       warning: ''
     };
     const actual = analyzeDependencies(options);

--- a/lib/read-checklist-file.js
+++ b/lib/read-checklist-file.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const loadJsonFile = require('load-json-file');
+const transformListEntry = require('./transform-list-entry');
 
 const hasArrayNonStringEntry = array => array.filter(item => typeof item !== 'string').length > 0;
 
@@ -11,7 +12,9 @@ const readChecklistFile = path => {
     throw new Error('Invalid content of checklist JSON file.');
   }
 
-  return fileContent;
+  return fileContent.
+    map(transformListEntry).
+    filter(item => item);
 };
 
 module.exports = readChecklistFile;

--- a/lib/read-checklist-file.test.js
+++ b/lib/read-checklist-file.test.js
@@ -38,11 +38,25 @@ describe('readChecklistFile', () => {
 
   it('returns checklist content when it is an array of strings', () => {
     const checklistContent = [ 'react', 'other-string', 'foobar' ];
+    const expected = [
+      {
+        packageName: 'react',
+        versionRange: undefined
+      },
+      {
+        packageName: 'other-string',
+        versionRange: undefined
+      },
+      {
+        packageName: 'foobar',
+        versionRange: undefined
+      }
+    ];
 
     loadJsonFile.sync.mockImplementation(() => checklistContent);
 
     const actual = readChecklistFile();
 
-    expect(actual).toEqual(checklistContent);
+    expect(actual).toEqual(expected);
   });
 });

--- a/lib/run-cli.test.js
+++ b/lib/run-cli.test.js
@@ -125,11 +125,11 @@ describe('run(cli)', () => {
 
   describe('when analysis failed', () => {
     beforeEach(() => {
-      readChecklistFile.mockReturnValue([ 'react' ]);
+      readChecklistFile.mockReturnValue([{ packageName: 'react', versionRange: '>=15.0.0 < 16.4.0' }]);
       readDependencies.mockReturnValue({
         tree: {
-          name: 'angular',
-          version: '5.0.0'
+          name: 'react',
+          version: '16.4.1'
         },
         problems: 'missing peer dependency foobar'
       });
@@ -160,7 +160,7 @@ describe('run(cli)', () => {
 
   describe('when analysis succeeded', () => {
     beforeEach(() => {
-      readChecklistFile.mockReturnValue([ 'react' ]);
+      readChecklistFile.mockReturnValue([{ packageName: 'react', versionRange: '^16.0.0' }]);
       readDependencies.mockReturnValue({
         tree: {
           name: 'react',

--- a/lib/transform-list-entry.js
+++ b/lib/transform-list-entry.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const sanitize = entry => ( // eslint-disable-line
+  typeof entry !== 'string' ?
+    '' :
+    entry.trim()
+);
+
+const transformListEntry = entry => {
+  const sanitizedEntry = sanitize(entry);
+
+  if (!sanitizedEntry) {
+    return null;
+  }
+
+  const parts = sanitizedEntry.split('@');
+
+  if (sanitizedEntry.startsWith('@')) {
+    const [ , second, ...rest ] = parts;
+
+    return {
+      packageName: `@${second}`,
+      versionRange: rest.join('') || undefined // eslint-disable-line
+    };
+  }
+
+  const [ first, ...rest ] = parts;
+
+  return {
+    packageName: first,
+    versionRange: rest.join('') || undefined // eslint-disable-line
+  };
+};
+
+module.exports = transformListEntry;

--- a/lib/transform-list-entry.test.js
+++ b/lib/transform-list-entry.test.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const transformListEntry = require('./transform-list-entry');
+
+describe('transformListEntry', () => {
+  it('transforms null', () => {
+    const entry = null;
+    const expected = null;
+    const actual = transformListEntry(entry);
+
+    expect(actual).toEqual(expected);
+  });
+
+  it('transforms empty string', () => {
+    const entry = '';
+    const expected = null;
+    const actual = transformListEntry(entry);
+
+    expect(actual).toEqual(expected);
+  });
+
+  it('transforms non string arg', () => {
+    const entry = 42;
+    const expected = null;
+    const actual = transformListEntry(entry);
+
+    expect(actual).toEqual(expected);
+  });
+
+  it('transforms string "react"', () => {
+    const entry = 'react';
+    const expected = { packageName: 'react', versionRange: undefined };
+    const actual = transformListEntry(entry);
+
+    expect(actual).toEqual(expected);
+  });
+
+  it('transforms string "react@2.1"', () => {
+    const entry = 'react@2.1';
+    const expected = { packageName: 'react', versionRange: '2.1' };
+    const actual = transformListEntry(entry);
+
+    expect(actual).toEqual(expected);
+  });
+
+  it('transforms string "@babel/core@7.0.0"', () => {
+    const entry = '@babel/core@7.0.0';
+    const expected = { packageName: '@babel/core', versionRange: '7.0.0' };
+    const actual = transformListEntry(entry);
+
+    expect(actual).toEqual(expected);
+  });
+
+  it('transforms string "@babel/core"', () => {
+    const entry = '@babel/core';
+    const expected = { packageName: '@babel/core', versionRange: undefined };
+    const actual = transformListEntry(entry);
+
+    expect(actual).toEqual(expected);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -5475,9 +5475,9 @@
       "dev": true
     },
     "semver": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
-      "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw=="
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
     },
     "semver-diff": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "load-json-file": "5.1.0",
     "meow": "5.0.0",
     "ora": "3.0.0",
+    "semver": "5.6.0",
     "update-notifier": "2.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This pull request closes issue #2.
It introduces support for certain versions or version ranges as allowed/disallowed.

Specifying the version range is optional.

Example list:
```javascript
[
  "react",
  "react-dom@^2.2.1",
  "redux@>=1.0.0-rc.0 <1.0.1",
  "react-redux@^2 <2.2 || > 2.3"
]
```