### PR TITLE
sets shell option to true for childprocess

### DIFF
--- a/lib/read-dependencies.js
+++ b/lib/read-dependencies.js
@@ -7,8 +7,12 @@ const readDependencies = (options = []) => {
 
   options.forEach(option => args.push(`--${option}`));
 
-  const result = childProcess.spawnSync('npm', args);
+  const result = childProcess.spawnSync('npm', args, { shell: true });
   const tree = JSON.parse(result.stdout);
+
+  if (!tree) {
+    throw new Error('Failed to read dependencies');
+  }
 
   // mark root level -> we want to exclude this level from analysis
   tree.isRoot = true;

--- a/lib/read-dependencies.test.js
+++ b/lib/read-dependencies.test.js
@@ -41,7 +41,7 @@ describe('readDependencies', () => {
     it('calls child_process.spawnSync "npm ls --json"', () => {
       readDependencies();
 
-      expect(childProcess.spawnSync).toHaveBeenCalledWith('npm', [ 'ls', '--json' ]);
+      expect(childProcess.spawnSync).toHaveBeenCalledWith('npm', [ 'ls', '--json' ], { shell: true });
     });
 
     it('returns parsed json returned by child process', () => {
@@ -59,7 +59,7 @@ describe('readDependencies', () => {
     it('calls child_process.spawnSync "npm ls --json --production"', () => {
       readDependencies([ 'production' ]);
 
-      expect(childProcess.spawnSync).toHaveBeenCalledWith('npm', [ 'ls', '--json', '--production' ]);
+      expect(childProcess.spawnSync).toHaveBeenCalledWith('npm', [ 'ls', '--json', '--production' ], { shell: true });
     });
 
     it('returns parsed json returned by child process', () => {
@@ -77,7 +77,7 @@ describe('readDependencies', () => {
     it('calls child_process.spawnSync "npm ls --json --development"', () => {
       readDependencies([ 'development' ]);
 
-      expect(childProcess.spawnSync).toHaveBeenCalledWith('npm', [ 'ls', '--json', '--development' ]);
+      expect(childProcess.spawnSync).toHaveBeenCalledWith('npm', [ 'ls', '--json', '--development' ], { shell: true });
     });
 
     it('returns parsed json returned by child process', () => {
@@ -89,6 +89,12 @@ describe('readDependencies', () => {
 
       expect(actual).toEqual(expected);
     });
+  });
+
+  it('throws when parsed tree is null', () => {
+    childProcess.spawnSync.mockImplementation(() => ({ stdout: null }));
+
+    expect(readDependencies).toThrow('Failed to read dependencies');
   });
 
   it('returns problems found by npm ls', () => {


### PR DESCRIPTION
This pull request closes issue #5.
For better windows support it passes option `{ shell: true }` to `childProcess.spawnSync(...)`.