### PR TITLE
Add support for custom exit code in case of failure

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -20,13 +20,14 @@ const cli = meow(`
                            Note: You cannot use --topLevelOnly together
                            with --depth.
     --depth                Max depth of the dependency tree analysis.
-                           default: Infinity
+                           Default: Infinity
                            Note: You cannot use --depth together
                            with --topLevelOnly.
     --blacklist    -black  Interpret content of checklist as blacklist.
     --development  -dev    Analyze the dependency tree for devDependencies.
     --production   -prod   Analyze the dependency tree for dependencies.
     --verbose              Lists unallowed dependencies.
+    --exitCode             Exit code in case of unallowed dependencies. Default: 1
     --version      -v      Displays the version number.
     --help         -h      Displays the help.
 
@@ -64,6 +65,9 @@ const cli = meow(`
     },
     verbose: {
       type: 'boolean'
+    },
+    exitCode: {
+      type: 'number'
     }
   }
 });

--- a/lib/run-cli.js
+++ b/lib/run-cli.js
@@ -52,7 +52,7 @@ const run = cli => {
     }
   }
 
-  process.exit(1);
+  process.exit(cli.flags.exitCode || 1);
 };
 
 module.exports = run;

--- a/lib/run-cli.test.js
+++ b/lib/run-cli.test.js
@@ -146,7 +146,7 @@ describe('run(cli)', () => {
       expect(spinnerFail).toHaveBeenCalledWith('Found 1 unallowed dependencies!');
     });
 
-    it('calls process.exit(1)', () => {
+    it('calls process.exit(1) by default', () => {
       const cli = {
         input: [ './path/to/checklist.json' ],
         flags: { }
@@ -155,6 +155,17 @@ describe('run(cli)', () => {
       run(cli);
 
       expect(processExit).toHaveBeenCalledWith(1);
+    });
+
+    it('calls process.exit() with the defined exit code', () => {
+      const cli = {
+        input: [ './path/to/checklist.json' ],
+        flags: { exitCode: 2 }
+      };
+
+      run(cli);
+
+      expect(processExit).toHaveBeenCalledWith(2);
     });
   });
 


### PR DESCRIPTION
Hej @chrkhl,

this is needed for setting the build as »unstable« instead of »failed« if someone don’t want to break their build in dev mode.

Cheers, Michael